### PR TITLE
Fix generator issues

### DIFF
--- a/lib/src/generator/generator.dart
+++ b/lib/src/generator/generator.dart
@@ -37,16 +37,17 @@ Future<void> generate([String path = 'l10n.yaml']) async {
         final key = line.split(' ')[1].split('(').first;
         final paramPairs = lines[i].split('(').last.split(')')[0].split(',');
 
+        // Parameters map of entries name:type, e.g. 'count':'int'
         final parameters = <String, String>{};
 
         for (var pair in paramPairs) {
           final parts = pair.trim().split(' ');
-          parameters[parts[0].trimRight()] = parts[1].trimLeft();
+          parameters[parts[1].trimRight()] = parts[0].trimLeft();
         }
 
         output.writeln(_generateMethod(key, parameters));
       }
-    } else if(line.startsWith('//')) {
+    } else if (line.startsWith('//')) {
       lastComments.add(lines[i]);
     } else {
       lastComments.clear();
@@ -66,11 +67,13 @@ String _generateField(String key) {
 }
 
 String _generateMethod(String key, Map<String, String> parameters) {
-  final sParameters = parameters.entries.map((e) => '${e.key} ${e.value}').join(', ');
-  final sParameterNames = parameters.values.join(', ');
+  final sParameters =
+      parameters.entries.map((e) => '${e.value} ${e.key}').join(', ');
+  final sParameterNames = parameters.keys.join(', ');
 
   // like _arb.get('title', {'name': name}) for arb string '"title": "translated title {name}"'
-  final sArbCall = '_arb.get(\'$key\', {${parameters.values.map((e) => '\'$e\': $e').join(', ')}})';
+  final sArbCall =
+      '_arb.get(\'$key\', {${parameters.keys.map((e) => '\'$e\': $e').join(', ')}})';
 
   return '\tString $key($sParameters) => $sArbCall ?? base.$key($sParameterNames);';
 }

--- a/lib/src/generator/generator.dart
+++ b/lib/src/generator/generator.dart
@@ -35,15 +35,17 @@ Future<void> generate([String path = 'l10n.yaml']) async {
         output.writeln(_generateField(key));
       } else {
         final key = line.split(' ')[1].split('(').first;
-        final paramPairs = lines[i].split('(').last.split(')')[0].split(',');
+        final methodSignature = _getMethodSignature(lines, i);
+        i += methodSignature.length - 1;
+        final paramPairs =
+            methodSignature.join(' ').split('(').last.split(')')[0].split(',');
 
-        // Parameters map of entries name:type, e.g. 'count':'int'
-        final parameters = <String, String>{};
-
-        for (var pair in paramPairs) {
-          final parts = pair.trim().split(' ');
-          parameters[parts[1].trimRight()] = parts[0].trimLeft();
-        }
+        // Parameters map of name:type, e.g. 'count':'int'
+        final parameters = {
+          for (final pair in paramPairs)
+            if (pair.trim().split(' ') case final parts when parts.length > 1)
+              parts[1].trimRight(): parts[0].trimLeft(),
+        };
 
         output.writeln(_generateMethod(key, parameters));
       }
@@ -60,6 +62,15 @@ Future<void> generate([String path = 'l10n.yaml']) async {
   output.writeln(footer.replaceAll('@(baseClass)', yaml.outputClass).trim());
 
   await output.close();
+}
+
+List<String> _getMethodSignature(List<String> lines, int start) {
+  for (var i = start; i < lines.length; i++) {
+    if (lines[i].contains(';')) {
+      return lines.sublist(start, i + 1);
+    }
+  }
+  return lines.sublist(start);
 }
 
 String _generateField(String key) {

--- a/lib/src/generator/model/templates.dart
+++ b/lib/src/generator/model/templates.dart
@@ -17,7 +17,7 @@ class @(baseClass)Remote extends @(baseClass) {
   final @(baseClass) base;
   final ArbWorker _arb;
   
-  static const LocalizationsDelegate<@(baseClass)> delegate = _L10nDelegateWithOta(L10n.delegate);
+  static const LocalizationsDelegate<@(baseClass)> delegate = _@(baseClass)DelegateWithOta(@(baseClass).delegate);
   
   /// A list of this localizations delegate along with the default localizations
   /// delegates.
@@ -39,7 +39,6 @@ class @(baseClass)Remote extends @(baseClass) {
   /// A list of this localizations delegate's supported locales.
   static const List<Locale> supportedLocales = @(baseClass).supportedLocales;
 ''';
-
 
 const footer = '''
 class _@(baseClass)DelegateWithOta extends LocalizationsDelegate<@(baseClass)> {


### PR DESCRIPTION
1. Support multiple parameters with the same type e.g.
```dart
String helloEveryone(String person1, String person2, String person3);
```

2. Replace hardcoded class name in the template.

3. Support multiline method signatures e.g.
```dart
String reallyLongNameThatWillCauseDartFormatterToSplitLines(
    String parameter1,
    String parameter2,
);
```

2 and 3 can be solved by using the default L10n class name and turning off the dart formatter but 1 needed a real fix.